### PR TITLE
feat: add Google AI SDK support for Python, Node.js, and Bun.js

### DIFF
--- a/bunjs/templates.yaml
+++ b/bunjs/templates.yaml
@@ -21,6 +21,17 @@
     - action: create_file
       filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
       from: "common/js/anthropic.ts"
+- name: "Google AI SDK for Typescript"
+  description: "Official TypeScript library for the Google AI"
+  steps:
+    - command: bun
+      args:
+        - add
+        - --silent
+        - "@google/genai"
+    - action: create_file
+      filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
+      from: "common/js/google.ts"
 - name: "Vercel AI SDK with OpenAI"
   description: "Vercel AI SDK is a TypeScript SDK for building AI powered applications. This template adds the OpenAI provider using the Vercel AI SDK."
   steps:
@@ -45,6 +56,18 @@
     - action: create_file
       filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
       from: "common/js/vercel/anthropic.ts"
+- name: "Vercel AI SDK with Google"
+  description: "Vercel AI SDK is a TypeScript SDK for building AI powered applications. This template adds the Google provider using the Vercel AI SDK."
+  steps:
+    - command: bun
+      args:
+        - add
+        - --silent
+        - ai
+        - "@ai-sdk/google"
+    - action: create_file
+      filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
+      from: "common/js/vercel/google.ts"      
 - name: "Mastra TypeScript Agent Framework"
   description: "Mastra is a TypeScript agent framework that provides primitives to build AI applications and features."
   steps:

--- a/common/js/google.ts
+++ b/common/js/google.ts
@@ -1,0 +1,18 @@
+import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
+import { GoogleGenAI } from "@google/genai";
+
+// Get your API key here: https://aistudio.google.com/apikey
+const google = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY! });
+
+export default async function Agent(
+  req: AgentRequest,
+  resp: AgentResponse,
+  ctx: AgentContext
+) {
+  const message = await google.models.generateContent({
+    model: "gemini-2.0-flash",
+    contents: (await req.data.text()) ?? "Explain how AI works in a few words",
+  });
+
+  return resp.text(message.text ?? "");
+}

--- a/common/js/google.ts
+++ b/common/js/google.ts
@@ -4,6 +4,23 @@ import { GoogleGenAI } from "@google/genai";
 // Get your API key here: https://aistudio.google.com/apikey
 const google = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY! });
 
+export const welcome = () => {
+  return {
+    welcome:
+      "Welcome to the Google AI TypeScript Agent! I can help you interact with Gemini models for natural language tasks.",
+    prompts: [
+      {
+        data: "Write a creative story about a journey through time",
+        contentType: "text/plain",
+      },
+      {
+        data: "Explain quantum computing to a high school student",
+        contentType: "text/plain",
+      },
+    ],
+  };
+};
+
 export default async function Agent(
   req: AgentRequest,
   resp: AgentResponse,

--- a/common/js/vercel/google.ts
+++ b/common/js/vercel/google.ts
@@ -2,6 +2,23 @@ import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
 import { generateText } from "ai";
 import { google } from "@ai-sdk/google";
 
+export const welcome = () => {
+  return {
+    welcome:
+      "Welcome to the Vercel AI SDK with Google AI Agent! I can help you build AI-powered applications using Vercel's AI SDK with Gemini models.",
+    prompts: [
+      {
+        data: "How do I implement streaming responses with Claude models?",
+        contentType: "text/plain",
+      },
+      {
+        data: "What are the best practices for prompt engineering with Claude?",
+        contentType: "text/plain",
+      },
+    ],
+  };
+};
+
 export default async function Agent(
   req: AgentRequest,
   resp: AgentResponse,

--- a/common/js/vercel/google.ts
+++ b/common/js/vercel/google.ts
@@ -1,0 +1,16 @@
+import type { AgentRequest, AgentResponse, AgentContext } from "@agentuity/sdk";
+import { generateText } from "ai";
+import { google } from "@ai-sdk/google";
+
+export default async function Agent(
+  req: AgentRequest,
+  resp: AgentResponse,
+  ctx: AgentContext
+) {
+  const res = await generateText({
+    model: google("gemini-2.0-flash"),
+    system: "You are a friendly assistant!",
+    prompt: (await req.data.text()) ?? "Why is the sky blue?",
+  });
+  return resp.text(res.text);
+}

--- a/common/py/google.py
+++ b/common/py/google.py
@@ -9,6 +9,20 @@ if not api_key:
 
 client = genai.Client(api_key=api_key)
 
+def welcome():  
+    return {  
+        "welcome": "Welcome to the Google AI Agent! I can help you interact with Gemini models for natural language tasks.",  
+        "prompts": [  
+            {  
+                "data": "Write a creative story about a journey through time",  
+                "contentType": "text/plain"  
+            },  
+            {  
+                "data": "Explain quantum computing to a high school student",  
+                "contentType": "text/plain"  
+            }  
+        ]  
+    }
 
 async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
     

--- a/common/py/google.py
+++ b/common/py/google.py
@@ -1,0 +1,18 @@
+from google import genai
+from agentuity import AgentRequest, AgentResponse, AgentContext
+import os
+
+api_key = os.getenv("GOOGLE_API_KEY")
+if not api_key:
+    raise ValueError("GOOGLE_API_KEY environment variable not set.")
+
+client = genai.Client(api_key=api_key)
+
+
+async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
+    
+    chat_completion = client.models.generate_content(
+        model="gemini-2.0-flash", contents= await request.data.text() or "Why is the sky blue?"
+    )
+    
+    return response.text(chat_completion.text)

--- a/common/py/google.py
+++ b/common/py/google.py
@@ -2,6 +2,7 @@ from google import genai
 from agentuity import AgentRequest, AgentResponse, AgentContext
 import os
 
+# Get your API key here: https://aistudio.google.com/apikey
 api_key = os.getenv("GOOGLE_API_KEY")
 if not api_key:
     raise ValueError("GOOGLE_API_KEY environment variable not set.")

--- a/nodejs/templates.yaml
+++ b/nodejs/templates.yaml
@@ -23,6 +23,18 @@
     - action: create_file
       filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
       from: "common/js/anthropic.ts"
+- name: "Google AI SDK for Typescript"
+  description: "Official TypeScript library for the Google AI"
+  steps:
+    - command: npm
+      args:
+        - install
+        - --no-fund
+        - --no-audit
+        - "@google/genai"
+    - action: create_file
+      filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
+      from: "common/js/google.ts"
 - name: "Vercel AI SDK with OpenAI"
   description: "Vercel AI SDK is a TypeScript SDK for building AI powered applications. This template adds the OpenAI provider using the Vercel AI SDK."
   steps:
@@ -49,6 +61,19 @@
     - action: create_file
       filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
       from: "common/js/vercel/anthropic.ts"
+- name: "Vercel AI SDK with Google"
+  description: "Vercel AI SDK is a TypeScript SDK for building AI powered applications. This template adds the Google provider using the Vercel AI SDK."
+  steps:
+    - command: npm
+      args:
+      - install
+        - --no-fund
+        - --no-audit
+        - ai
+        - "@ai-sdk/google"
+    - action: create_file
+      filename: "src/agents/{{ .AgentName | safe_filename }}/index.ts"
+      from: "common/js/vercel/google.ts"         
 - name: "Mastra TypeScript Agent Framework"
   description: "Mastra is a TypeScript agent framework that provides primitives to build AI applications and features."
   steps:

--- a/python-uv/templates.yaml
+++ b/python-uv/templates.yaml
@@ -106,4 +106,3 @@
     - action: copy_dir
       from: "common/py/crewai/config"
       to: "agents/{{ .AgentName | safe_filename }}/config"
-

--- a/python-uv/templates.yaml
+++ b/python-uv/templates.yaml
@@ -41,6 +41,20 @@
     - action: create_file
       filename: "agents/{{ .AgentName | safe_filename }}/__init__.py"
       template: "common/py/init.py"
+- name: "Google GenAI"
+  description: "Google Generative AI Python SDK"
+  steps:
+    - command: uv
+      args:
+        - add
+        - --quiet
+        - google-genai
+    - action: create_file
+      filename: "agents/{{ .AgentName | safe_filename }}/agent.py"
+      from: "common/py/google.py"
+    - action: create_file
+      filename: "agents/{{ .AgentName | safe_filename }}/__init__.py"
+      template: "common/py/init.py"
 - name: "LangChain"
   description: "LangChain Python SDK with OpenAI"
   steps:
@@ -92,3 +106,4 @@
     - action: copy_dir
       from: "common/py/crewai/config"
       to: "agents/{{ .AgentName | safe_filename }}/config"
+


### PR DESCRIPTION
Added options for creating a basic Gemini agent.

In the past few months, Google's Gemini had dominated the [Lmarena leaderboard](https://lmarena.ai/?leaderboard).

It should be available as a starter template option.

includes:
- vanilla bun gen-ai starter
- vanilla node gen-ai starter 
- Ai SDK starter
- vanilla uv genai starter
