### PR TITLE
Add default disk limits and adjust python max required version to include patch versions of 3.12

### DIFF
--- a/bunjs/rules.yaml
+++ b/bunjs/rules.yaml
@@ -25,6 +25,7 @@ deployment:
   resources:
     memory: 250Mi
     cpu: 500M
+    disk: 100Mi
   command: bun
   args:
     - run

--- a/common/py/boot.py
+++ b/common/py/boot.py
@@ -5,7 +5,9 @@ from agentuity import autostart
 
 if __name__ == "__main__":
     # Check if AGENTUITY_API_KEY is set
-    if not os.environ.get("AGENTUITY_API_KEY") and not os.environ.get("AGENTUITY_SDK_KEY"):
+    if not os.environ.get("AGENTUITY_API_KEY") and not os.environ.get(
+        "AGENTUITY_SDK_KEY"
+    ):
         print(
             "\033[31m[ERROR] AGENTUITY_API_KEY or AGENTUITY_SDK_KEY is not set. This should have been set automatically by the Agentuity CLI or picked up from the .env file.\033[0m"
         )
@@ -26,6 +28,7 @@ if __name__ == "__main__":
 
     # Setup logging after environment checks
     logging.basicConfig(
+        stream=sys.stdout,
         level=logging.INFO,
         format="[%(levelname)-5.5s] %(message)s",
     )

--- a/nodejs/rules.yaml
+++ b/nodejs/rules.yaml
@@ -25,6 +25,7 @@ deployment:
   resources:
     memory: 250Mi
     cpu: 500M
+    disk: 100Mi
   command: node
   args:
     - --disable-sigusr1

--- a/python-uv/rules.yaml
+++ b/python-uv/rules.yaml
@@ -24,6 +24,7 @@ deployment:
   resources:
     memory: 250Mi
     cpu: 500M
+    disk: 150Mi
   command: uv
   args:
     - run
@@ -39,7 +40,7 @@ new_project:
       args:
         - venv
         - --python
-        - ">=3.10,<=3.12"
+        - ">=3.10,<3.13"
     - command: uv
       args:
         - init
@@ -47,7 +48,7 @@ new_project:
         - "{{ .Name | safe_filename }}"
         - --no-package
         - --python
-        - ">=3.10,<=3.12"
+        - ">=3.10,<3.13"
         - --description
         - "{{ .Description }}"
         - --no-readme

--- a/rules.schema.json
+++ b/rules.schema.json
@@ -103,7 +103,7 @@
       "properties": {
         "resources": {
           "type": "object",
-          "required": ["memory", "cpu"],
+          "required": ["memory", "cpu", "disk"],
           "properties": {
             "memory": {
               "type": "string",
@@ -112,6 +112,10 @@
             "cpu": {
               "type": "string",
               "description": "CPU resource limit"
+            },
+            "disk": {
+              "type": "string",
+              "description": "Disk resource limit"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added disk space limits to deployment configurations, requiring specification of disk resources alongside memory and CPU.
  - Updated resource limits for disk space in deployment settings for bunjs, nodejs, and python-uv environments.

- **Bug Fixes**
  - Adjusted Python version constraints in python-uv configuration to allow Python 3.12 but exclude 3.13 and above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->