### PR TITLE
Add support for using .env.development for non-production environment variables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ There are many ways you can contribute to this project:
 
 ## Questions or Need Help?
 
-- Join our [Discord community](https://discord.gg/vtn3hgUfuc)
+- Join our [Discord community](https://discord.gg/agentuity)
 - Check existing issues and discussions
 - Create a new issue for questions
 - Reach out to maintainers if needed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <strong>Build Agents, Not Infrastructure</strong> <br/>
 <br />
 <a href="https://github.com/agentuity/sdk-js/blob/main/README.md"><img alt="License" src="https://badgen.now.sh/badge/license/Apache-2.0"></a>
-<a href="https://discord.gg/vtn3hgUfuc"><img alt="Join the community on Discord" src="https://img.shields.io/discord/1332974865371758646.svg?style=flat"></a>
+<a href="https://discord.gg/agentuity"><img alt="Join the community on Discord" src="https://img.shields.io/discord/1332974865371758646.svg?style=flat"></a>
 </div>
 </div>
 

--- a/bunjs/rules.yaml
+++ b/bunjs/rules.yaml
@@ -94,6 +94,8 @@ new_project:
       content: |
         # don't commit the agentuity build folder
         .agentuity
+        .env.development
+        .env.production
     - action: create_file
       filename: "index.ts"
       from: "common/js/boot.ts"

--- a/bunjs/rules.yaml
+++ b/bunjs/rules.yaml
@@ -121,3 +121,6 @@ new_project:
     - action: create_file
       filename: "biome.json"
       from: "common/js/biome.json"
+    - action: create_file
+      filename: ".env.development"
+      from: "common/env.development"

--- a/bunjs/rules.yaml
+++ b/bunjs/rules.yaml
@@ -20,6 +20,8 @@ development:
   args:
     - run
     - --silent
+    - --env-file=.env
+    - --env-file=.env.development
     - .agentuity/index.js
 deployment:
   resources:

--- a/common/env.development
+++ b/common/env.development
@@ -1,0 +1,3 @@
+# These are the environment variables for the development environment
+# Any variables that are not set here will override the production environment variables
+# in the .env file when running agentuity dev

--- a/common/py/gitignore
+++ b/common/py/gitignore
@@ -129,6 +129,8 @@ celerybeat.pid
 
 # Environments
 .env
+.env.development
+.env.production
 .venv
 env/
 venv/

--- a/nodejs/gitignore
+++ b/nodejs/gitignore
@@ -20,6 +20,8 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .env.test.local
 .env.production.local
 .env.local
+.env.production
+.env.development
 
 # caches
 .eslintcache

--- a/nodejs/rules.yaml
+++ b/nodejs/rules.yaml
@@ -111,3 +111,6 @@ new_project:
     - action: create_file
       filename: "biome.json"
       from: "common/js/biome.json"
+    - action: create_file
+      filename: ".env.development"
+      from: "common/env.development"

--- a/nodejs/rules.yaml
+++ b/nodejs/rules.yaml
@@ -19,6 +19,7 @@ development:
   command: node
   args:
     - --env-file=.env
+    - --env-file-if-exists=.env.development
     - --no-deprecation
     - .agentuity/index.js
 deployment:

--- a/python-uv/rules.yaml
+++ b/python-uv/rules.yaml
@@ -19,6 +19,8 @@ development:
     - run
     - --env-file
     - .env
+    - --env-file
+    - .env.development
     - server.py
 deployment:
   resources:

--- a/python-uv/rules.yaml
+++ b/python-uv/rules.yaml
@@ -88,3 +88,6 @@ new_project:
     - action: create_file
       filename: "agents/__init__.py"
       template: "common/py/init.py"
+    - action: create_file
+      filename: ".env.development"
+      from: "common/env.development"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading environment variables from both `.env` and `.env.development` files during development runs for Bun, Node.js, and Python (uv) runtimes. This allows for more flexible environment configuration in development mode.
- **Chores**
  - Updated `.gitignore` files to exclude `.env.development` and `.env.production` environment files, preventing accidental commits of sensitive configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->