### PR TITLE
rename to agentuity-agents

### DIFF
--- a/python-uv/rules.yaml
+++ b/python-uv/rules.yaml
@@ -13,7 +13,7 @@ development:
   watch:
     enabled: true
     files:
-      - "agents/**"
+      - "agentuity-agents/**"
   command: uv
   args:
     - run
@@ -34,10 +34,10 @@ deployment:
 new_agent:
   steps:
     - action: create_file
-      filename: "agents/{{ .Name | safe_filename }}/agent.py"
+      filename: "agentuity-agents/{{ .Name | safe_filename }}/agent.py"
       from: "common/py/agent.py"
     - action: create_file
-      filename: "agents/{{ .Name | safe_filename }}/__init__.py"
+      filename: "agentuity-agents/{{ .Name | safe_filename }}/__init__.py"
       from: "common/py/init.py"
 new_project:
   steps:
@@ -89,7 +89,7 @@ new_project:
       filename: ".editorconfig"
       template: "common/editorconfig"
     - action: create_file
-      filename: "agents/__init__.py"
+      filename: "agentuity-agents/__init__.py"
       template: "common/py/init.py"
     - action: create_file
       filename: ".env.development"


### PR DESCRIPTION
Change the `/agents` directory to `agentuity-agents` to avoid conflicts with openAI `agents` SDK. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration to reference a new directory name for agent-related files and patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->