### PR TITLE
unify the settings for .editorconfig and biome

### DIFF
--- a/common/editorconfig
+++ b/common/editorconfig
@@ -4,9 +4,13 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[*.py]
+indent_style = space
+indent_size = 2

--- a/common/editorconfig
+++ b/common/editorconfig
@@ -9,8 +9,4 @@ indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
-insert_final_newline = false
-
-[*.py]
-indent_style = space
-indent_size = 2
+insert_final_newline = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated default indentation to 2 spaces across all files.
  - Added specific configuration for Python files to use 2-space indentation.
  - Ensured all files end with a newline for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->